### PR TITLE
parent child locks

### DIFF
--- a/glock-server/cmd/main.go
+++ b/glock-server/cmd/main.go
@@ -37,9 +37,6 @@ func main() {
 		Config:   config,
 	}
 
-	locks.StartCleanupGoroutine()
-	defer locks.StopCleanupGoroutine()
-
 	r := gin.Default()
 
 	r.Static("/static", "./static")

--- a/glock-server/cmd/main.go
+++ b/glock-server/cmd/main.go
@@ -35,6 +35,7 @@ func main() {
 		Size:     0,
 		Capacity: config.Capacity,
 		Locks:    sync.Map{},
+		LockTree: core.NewLockTree(),
 		Config:   config,
 	}
 

--- a/glock-server/cmd/main.go
+++ b/glock-server/cmd/main.go
@@ -21,7 +21,6 @@ import (
 // @host localhost:8080
 // @BasePath /
 func main() {
-	// Load configuration
 	configFile := os.Getenv("GLOCK_CONFIG_FILE")
 	config, err := core.LoadConfig(configFile)
 	if err != nil {
@@ -30,7 +29,6 @@ func main() {
 
 	log.Printf("Starting glock server with config: %+v", config)
 
-	// Initialize server
 	locks := &core.GlockServer{
 		Size:     0,
 		Capacity: config.Capacity,
@@ -39,22 +37,17 @@ func main() {
 		Config:   config,
 	}
 
-	// Start background cleanup goroutine for TTL expiration processing
 	locks.StartCleanupGoroutine()
 	defer locks.StopCleanupGoroutine()
 
-	// Setup Gin router
 	r := gin.Default()
 
-	// Serve static files for the dashboard
 	r.Static("/static", "./static")
 	r.StaticFile("/favicon.ico", "./static/favicon.ico")
 	r.StaticFile("/", "./static/index.html")
 
-	// API routes group
 	api := r.Group("/api")
 	{
-		// Lock management endpoints
 		api.POST("/create", func(c *gin.Context) {
 			core.CreateHandler(c, locks)
 		})
@@ -92,7 +85,6 @@ func main() {
 			core.UnfreezeLockHandler(c, locks)
 		})
 
-		// Status and listing endpoints
 		api.GET("/status", func(c *gin.Context) {
 			core.StatusHandler(c, locks)
 		})
@@ -103,7 +95,6 @@ func main() {
 			core.MetricsHandler(c, locks)
 		})
 
-		// Configuration endpoints
 		api.GET("/config", func(c *gin.Context) {
 			core.ConfigHandler(c, locks)
 		})
@@ -112,10 +103,8 @@ func main() {
 		})
 	}
 
-	// Swagger UI endpoint
 	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
-	// Start server
 	addr := fmt.Sprintf("%s:%d", config.Host, config.Port)
 	log.Printf("Starting server on %s", addr)
 	if err := r.Run(addr); err != nil {

--- a/glock-server/core/config.go
+++ b/glock-server/core/config.go
@@ -12,23 +12,18 @@ import (
 // Config holds all configuration for the glock server
 // @Description Config holds all configuration for the glock server
 type Config struct {
-	// Server configuration
 	Port int    `yaml:"port" json:"port" example:"8080"`
 	Host string `yaml:"host" json:"host" example:"localhost"`
 
-	// Lock configuration
 	Capacity            int           `yaml:"capacity" json:"capacity" example:"1000"`
 	DefaultTTL          time.Duration `yaml:"default_ttl" json:"default_ttl" swaggertype:"string" example:"30s"`
 	DefaultMaxTTL       time.Duration `yaml:"default_max_ttl" json:"default_max_ttl" swaggertype:"string" example:"5m"`
 	DefaultQueueTimeout time.Duration `yaml:"default_queue_timeout" json:"default_queue_timeout" swaggertype:"string" example:"5m"`
 
-	// Metrics configuration
 	OwnerHistoryMaxSize int `yaml:"owner_history_max_size" json:"owner_history_max_size" example:"100"`
 
-	// Queue configuration
 	QueueMaxSize int `yaml:"queue_max_size" json:"queue_max_size" example:"1024"`
 
-	// Cleanup configuration
 	CleanupInterval time.Duration `yaml:"cleanup_interval" json:"cleanup_interval" swaggertype:"string" example:"30s"`
 }
 
@@ -168,19 +163,16 @@ func (c *Config) Validate() error {
 func LoadConfig(yamlFile string) (*Config, error) {
 	config := DefaultConfig()
 
-	// Load from YAML file if provided
 	if yamlFile != "" {
 		if err := config.LoadFromYAML(yamlFile); err != nil {
 			return nil, err
 		}
 	}
 
-	// Load from environment variables (overrides YAML)
 	if err := config.LoadFromEnv(); err != nil {
 		return nil, err
 	}
 
-	// Validate the final configuration
 	if err := config.Validate(); err != nil {
 		return nil, err
 	}

--- a/glock-server/core/handlers_test.go
+++ b/glock-server/core/handlers_test.go
@@ -38,6 +38,7 @@ func TestHandlers_CreateAcquireRelease(t *testing.T) {
 	g := &GlockServer{
 		Capacity: 10,
 		Locks:    sync.Map{},
+		LockTree: NewLockTree(),
 		Config:   config,
 	}
 	r := setupRouter(g)
@@ -87,6 +88,7 @@ func TestHandlers_Status(t *testing.T) {
 	g := &GlockServer{
 		Capacity: 10,
 		Locks:    sync.Map{},
+		LockTree: NewLockTree(),
 		Config:   config,
 	}
 	r := setupRouter(g)

--- a/glock-server/core/hierarchy_race_test.go
+++ b/glock-server/core/hierarchy_race_test.go
@@ -1,0 +1,514 @@
+package core
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestConcurrentParentChildAcquire tests race conditions when acquiring parent and child simultaneously
+func TestConcurrentParentChildAcquire(t *testing.T) {
+	g := newServer(10)
+
+	_, _, _ = g.CreateLock(&CreateRequest{
+		Name:         "parent",
+		TTL:          "1s",
+		MaxTTL:       "5m",
+		QueueType:    QueueFIFO,
+		QueueTimeout: "1m",
+	})
+	_, _, _ = g.CreateLock(&CreateRequest{
+		Name:         "child",
+		Parent:       "parent",
+		TTL:          "1s",
+		MaxTTL:       "5m",
+		QueueType:    QueueFIFO,
+		QueueTimeout: "1m",
+	})
+
+	var wg sync.WaitGroup
+	results := make(chan string, 2)
+
+	// Try to acquire parent and child concurrently
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, code, _ := g.AcquireLock(&AcquireRequest{
+			Name:    "parent",
+			Owner:   "owner1",
+			OwnerID: "11111111-1111-1111-1111-111111111111",
+		})
+		if code == 200 {
+			results <- "parent-acquired"
+		} else if code == 202 {
+			results <- "parent-queued"
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		_, code, _ := g.AcquireLock(&AcquireRequest{
+			Name:    "child",
+			Owner:   "owner2",
+			OwnerID: "22222222-2222-2222-2222-222222222222",
+		})
+		if code == 200 {
+			results <- "child-acquired"
+		} else if code == 202 {
+			results <- "child-queued"
+		}
+	}()
+
+	wg.Wait()
+	close(results)
+
+	// One should succeed, one should queue or vice versa
+	acquired := 0
+	queued := 0
+	for result := range results {
+		if result == "parent-acquired" || result == "child-acquired" {
+			acquired++
+		} else {
+			queued++
+		}
+	}
+
+	if acquired == 0 {
+		t.Fatal("at least one lock should have been acquired")
+	}
+	if acquired == 2 {
+		t.Fatal("both parent and child cannot be held simultaneously")
+	}
+}
+
+// TestReleaseWhileAcquiring tests releasing a lock while another is trying to acquire
+func TestReleaseWhileAcquiring(t *testing.T) {
+	g := newServer(10)
+
+	_, _, _ = g.CreateLock(&CreateRequest{
+		Name:         "parent",
+		TTL:          "100ms",
+		MaxTTL:       "5m",
+		QueueType:    QueueFIFO,
+		QueueTimeout: "1m",
+	})
+	_, _, _ = g.CreateLock(&CreateRequest{
+		Name:         "child",
+		Parent:       "parent",
+		TTL:          "100ms",
+		MaxTTL:       "5m",
+		QueueType:    QueueFIFO,
+		QueueTimeout: "1m",
+	})
+
+	// Acquire parent
+	result, _, _ := g.AcquireLock(&AcquireRequest{
+		Name:    "parent",
+		Owner:   "owner1",
+		OwnerID: "11111111-1111-1111-1111-111111111111",
+	})
+	parentLock := result.(*Lock)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Goroutine 1: Try to acquire child (will queue)
+	go func() {
+		defer wg.Done()
+		g.AcquireLock(&AcquireRequest{
+			Name:    "child",
+			Owner:   "owner2",
+			OwnerID: "22222222-2222-2222-2222-222222222222",
+		})
+	}()
+
+	// Goroutine 2: Release parent after short delay
+	go func() {
+		defer wg.Done()
+		time.Sleep(10 * time.Millisecond)
+		g.ReleaseLock(&ReleaseRequest{
+			Name:    "parent",
+			OwnerID: "11111111-1111-1111-1111-111111111111",
+			Token:   parentLock.Token,
+		})
+	}()
+
+	wg.Wait()
+
+	// Child should eventually get the lock from queue
+	time.Sleep(50 * time.Millisecond)
+	nodeVal, _ := g.Locks.Load("child")
+	childLock := nodeVal.(*Node).Lock
+	childLock.mu.Lock()
+	owner := childLock.OwnerID
+	childLock.mu.Unlock()
+
+	if owner != "22222222-2222-2222-2222-222222222222" {
+		t.Fatalf("child should have been granted from queue, got owner: %s", owner)
+	}
+}
+
+// TestCycleDetection tests that cycles in parent chains are prevented
+func TestCycleDetection(t *testing.T) {
+	g := newServer(10)
+
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "A", TTL: "1s", MaxTTL: "1m"})
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "B", Parent: "A", TTL: "1s", MaxTTL: "1m"})
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "C", Parent: "B", TTL: "1s", MaxTTL: "1m"})
+
+	// Try to make A a child of C (would create cycle: A -> B -> C -> A)
+	_, code, err := g.UpdateLock(&UpdateRequest{
+		Name:   "A",
+		Parent: "C",
+		TTL:    "1s",
+		MaxTTL: "1m",
+	})
+
+	if err == nil || code != 400 {
+		t.Fatalf("expected bad request when creating cycle, got code=%d err=%v", code, err)
+	}
+	if err.Error() != "cannot set parent: would create a cycle in lock hierarchy" {
+		t.Fatalf("unexpected error message: %s", err.Error())
+	}
+}
+
+// TestDeepHierarchy tests a deep hierarchy (10+ levels)
+func TestDeepHierarchy(t *testing.T) {
+	g := newServer(20)
+
+	// Create 10-level hierarchy
+	_, _, _ = g.CreateLock(&CreateRequest{
+		Name:         "level0",
+		TTL:          "1s",
+		MaxTTL:       "5m",
+		QueueType:    QueueFIFO,
+		QueueTimeout: "1m",
+	})
+
+	for i := 1; i < 10; i++ {
+		parentName := "level" + string(rune('0'+i-1))
+		lockName := "level" + string(rune('0'+i))
+		_, _, err := g.CreateLock(&CreateRequest{
+			Name:         lockName,
+			Parent:       parentName,
+			TTL:          "1s",
+			MaxTTL:       "5m",
+			QueueType:    QueueFIFO,
+			QueueTimeout: "1m",
+		})
+		if err != nil {
+			t.Fatalf("failed to create lock at level %d: %v", i, err)
+		}
+	}
+
+	// Acquire root
+	result, code, err := g.AcquireLock(&AcquireRequest{
+		Name:    "level0",
+		Owner:   "owner1",
+		OwnerID: "11111111-1111-1111-1111-111111111111",
+	})
+	if err != nil || code != 200 {
+		t.Fatalf("failed to acquire root: code=%d err=%v", code, err)
+	}
+	rootLock := result.(*Lock)
+
+	// Try to acquire leaf (should queue)
+	_, code, _ = g.AcquireLock(&AcquireRequest{
+		Name:    "level9",
+		Owner:   "owner2",
+		OwnerID: "22222222-2222-2222-2222-222222222222",
+	})
+	if code != 202 {
+		t.Fatalf("expected leaf to queue when root held, got code=%d", code)
+	}
+
+	// Release root
+	_, _, _ = g.ReleaseLock(&ReleaseRequest{
+		Name:    "level0",
+		OwnerID: "11111111-1111-1111-1111-111111111111",
+		Token:   rootLock.Token,
+	})
+
+	// Leaf should now be granted
+	time.Sleep(10 * time.Millisecond)
+	nodeVal, _ := g.Locks.Load("level9")
+	leafLock := nodeVal.(*Node).Lock
+	leafLock.mu.Lock()
+	owner := leafLock.OwnerID
+	leafLock.mu.Unlock()
+
+	if owner != "22222222-2222-2222-2222-222222222222" {
+		t.Fatalf("leaf should have been granted from queue, got owner: %s", owner)
+	}
+}
+
+// TestParentWithMultipleChildrenQueued tests one parent with multiple children all queued
+func TestParentWithMultipleChildrenQueued(t *testing.T) {
+	g := newServer(20)
+
+	_, _, _ = g.CreateLock(&CreateRequest{
+		Name:         "parent",
+		TTL:          "1s",
+		MaxTTL:       "5m",
+		QueueType:    QueueFIFO,
+		QueueTimeout: "1m",
+	})
+
+	// Create 5 children
+	for i := 0; i < 5; i++ {
+		childName := "child" + string(rune('0'+i))
+		_, _, _ = g.CreateLock(&CreateRequest{
+			Name:         childName,
+			Parent:       "parent",
+			TTL:          "1s",
+			MaxTTL:       "5m",
+			QueueType:    QueueFIFO,
+			QueueTimeout: "1m",
+		})
+	}
+
+	// Acquire parent
+	result, _, _ := g.AcquireLock(&AcquireRequest{
+		Name:    "parent",
+		Owner:   "owner-parent",
+		OwnerID: "00000000-0000-0000-0000-000000000000",
+	})
+	parentLock := result.(*Lock)
+
+	// Queue all children
+	for i := 0; i < 5; i++ {
+		childName := "child" + string(rune('0'+i))
+		ownerID := "11111111-1111-1111-1111-11111111111" + string(rune('0'+i))
+		_, code, _ := g.AcquireLock(&AcquireRequest{
+			Name:    childName,
+			Owner:   "owner" + string(rune('0'+i)),
+			OwnerID: ownerID,
+		})
+		if code != 202 {
+			t.Fatalf("child%d should have been queued, got code=%d", i, code)
+		}
+	}
+
+	// Release parent
+	_, _, _ = g.ReleaseLock(&ReleaseRequest{
+		Name:    "parent",
+		OwnerID: "00000000-0000-0000-0000-000000000000",
+		Token:   parentLock.Token,
+	})
+
+	// All children should now be granted from their queues
+	time.Sleep(50 * time.Millisecond)
+	for i := 0; i < 5; i++ {
+		childName := "child" + string(rune('0'+i))
+		expectedOwner := "11111111-1111-1111-1111-11111111111" + string(rune('0'+i))
+
+		nodeVal, _ := g.Locks.Load(childName)
+		childLock := nodeVal.(*Node).Lock
+		childLock.mu.Lock()
+		owner := childLock.OwnerID
+		childLock.mu.Unlock()
+
+		if owner != expectedOwner {
+			t.Fatalf("child%d should have been granted from queue, got owner: %s, expected: %s", i, owner, expectedOwner)
+		}
+	}
+}
+
+// TestMixedQueuePriority tests when parent and child both have queues
+func TestMixedQueuePriority(t *testing.T) {
+	g := newServer(10)
+
+	_, _, _ = g.CreateLock(&CreateRequest{
+		Name:         "parent",
+		TTL:          "1s",
+		MaxTTL:       "5m",
+		QueueType:    QueueFIFO,
+		QueueTimeout: "1m",
+	})
+	_, _, _ = g.CreateLock(&CreateRequest{
+		Name:         "child",
+		Parent:       "parent",
+		TTL:          "1s",
+		MaxTTL:       "5m",
+		QueueType:    QueueFIFO,
+		QueueTimeout: "1m",
+	})
+
+	// Acquire parent
+	result, _, _ := g.AcquireLock(&AcquireRequest{
+		Name:    "parent",
+		Owner:   "owner1",
+		OwnerID: "11111111-1111-1111-1111-111111111111",
+	})
+	parentLock := result.(*Lock)
+
+	// Queue request for parent
+	g.AcquireLock(&AcquireRequest{
+		Name:    "parent",
+		Owner:   "owner2",
+		OwnerID: "22222222-2222-2222-2222-222222222222",
+	})
+
+	// Queue request for child
+	g.AcquireLock(&AcquireRequest{
+		Name:    "child",
+		Owner:   "owner3",
+		OwnerID: "33333333-3333-3333-3333-333333333333",
+	})
+
+	// Release parent
+	g.ReleaseLock(&ReleaseRequest{
+		Name:    "parent",
+		OwnerID: "11111111-1111-1111-1111-111111111111",
+		Token:   parentLock.Token,
+	})
+
+	// Parent queue should get precedence (owner2 gets parent)
+	time.Sleep(10 * time.Millisecond)
+	nodeVal, _ := g.Locks.Load("parent")
+	parentLockAfter := nodeVal.(*Node).Lock
+	parentLockAfter.mu.Lock()
+	parentOwner := parentLockAfter.OwnerID
+	parentLockAfter.mu.Unlock()
+
+	if parentOwner != "22222222-2222-2222-2222-222222222222" {
+		t.Fatalf("parent should have been granted to owner2, got: %s", parentOwner)
+	}
+
+	// Child should still be queued (parent is now held by owner2)
+	nodeVal, _ = g.Locks.Load("child")
+	childLock := nodeVal.(*Node).Lock
+	childLock.mu.Lock()
+	childOwner := childLock.OwnerID
+	queueSize := childLock.getCurrentQueueSize()
+	childLock.mu.Unlock()
+
+	if childOwner != "" {
+		t.Fatalf("child should not be granted while parent is held, got owner: %s", childOwner)
+	}
+	if queueSize != 1 {
+		t.Fatalf("child should still have 1 queued request, got: %d", queueSize)
+	}
+}
+
+// TestConcurrentReleaseAndAcquire tests race between release and acquire
+func TestConcurrentReleaseAndAcquire(t *testing.T) {
+	g := newServer(10)
+
+	_, _, _ = g.CreateLock(&CreateRequest{
+		Name:         "lock1",
+		TTL:          "1s",
+		MaxTTL:       "5m",
+		QueueType:    QueueFIFO,
+		QueueTimeout: "1m",
+	})
+
+	// Run many iterations to catch race conditions
+	for iter := 0; iter < 100; iter++ {
+		// Acquire
+		result, _, _ := g.AcquireLock(&AcquireRequest{
+			Name:    "lock1",
+			Owner:   "owner1",
+			OwnerID: "11111111-1111-1111-1111-111111111111",
+		})
+		lock := result.(*Lock)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		// Concurrent release and acquire
+		go func() {
+			defer wg.Done()
+			g.ReleaseLock(&ReleaseRequest{
+				Name:    "lock1",
+				OwnerID: "11111111-1111-1111-1111-111111111111",
+				Token:   lock.Token,
+			})
+		}()
+
+		go func() {
+			defer wg.Done()
+			g.AcquireLock(&AcquireRequest{
+				Name:    "lock1",
+				Owner:   "owner2",
+				OwnerID: "22222222-2222-2222-2222-222222222222",
+			})
+		}()
+
+		wg.Wait()
+
+		// Clean up - release if held
+		nodeVal, _ := g.Locks.Load("lock1")
+		currentLock := nodeVal.(*Node).Lock
+		currentLock.mu.Lock()
+		if currentLock.OwnerID != "" {
+			token := currentLock.Token
+			owner := currentLock.OwnerID
+			currentLock.mu.Unlock()
+			g.ReleaseLock(&ReleaseRequest{
+				Name:    "lock1",
+				OwnerID: owner,
+				Token:   token,
+			})
+		} else {
+			currentLock.mu.Unlock()
+		}
+	}
+}
+
+// TestUpdateParentConcurrently tests concurrent updates to parent relationships
+func TestUpdateParentConcurrently(t *testing.T) {
+	g := newServer(20)
+
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "A", TTL: "1s", MaxTTL: "1m"})
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "B", TTL: "1s", MaxTTL: "1m"})
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "C", TTL: "1s", MaxTTL: "1m"})
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "target", TTL: "1s", MaxTTL: "1m"})
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	// Try to set different parents concurrently
+	go func() {
+		defer wg.Done()
+		g.UpdateLock(&UpdateRequest{
+			Name:   "target",
+			Parent: "A",
+			TTL:    "1s",
+			MaxTTL: "1m",
+		})
+	}()
+
+	go func() {
+		defer wg.Done()
+		g.UpdateLock(&UpdateRequest{
+			Name:   "target",
+			Parent: "B",
+			TTL:    "1s",
+			MaxTTL: "1m",
+		})
+	}()
+
+	go func() {
+		defer wg.Done()
+		g.UpdateLock(&UpdateRequest{
+			Name:   "target",
+			Parent: "C",
+			TTL:    "1s",
+			MaxTTL: "1m",
+		})
+	}()
+
+	wg.Wait()
+
+	// Verify target has a valid parent (one of A, B, or C)
+	nodeVal, _ := g.Locks.Load("target")
+	targetLock := nodeVal.(*Node).Lock
+	targetLock.mu.Lock()
+	parent := targetLock.Parent
+	targetLock.mu.Unlock()
+
+	if parent != "A" && parent != "B" && parent != "C" {
+		t.Fatalf("target should have one of the parents, got: %s", parent)
+	}
+}

--- a/glock-server/core/lock.go
+++ b/glock-server/core/lock.go
@@ -27,17 +27,14 @@ type Lock struct {
 	Frozen       bool          `json:"frozen" example:"false"`
 	queue        *LockQueue    `json:"-"`
 	mu           sync.Mutex    `json:"-"`
-	metrics      *LockMetrics  `json:"-"` // Metrics tracking
-
+	metrics      *LockMetrics  `json:"-"`
 }
 
-// LockQueue manages queued lock acquisition requests
 type LockQueue struct {
-	requests map[string]*list.Element // requestID -> list element
-	list     *list.List               // doubly linked list for FIFO/LIFO
+	requests map[string]*list.Element
+	list     *list.List
 }
 
-// NewLockQueue creates a new queue for lock requests
 func NewLockQueue() *LockQueue {
 	return &LockQueue{
 		requests: make(map[string]*list.Element),
@@ -45,17 +42,14 @@ func NewLockQueue() *LockQueue {
 	}
 }
 
-// Enqueue adds a request to the queue
 func (q *LockQueue) Enqueue(req *QueueRequest, isLIFO bool) {
 	element := q.list.PushBack(req)
 	if isLIFO {
-		// For LIFO, move to front
 		q.list.MoveToFront(element)
 	}
 	q.requests[req.ID] = element
 }
 
-// Dequeue removes and returns the next request
 func (q *LockQueue) Dequeue() *QueueRequest {
 	if q.list.Len() == 0 {
 		return nil
@@ -68,7 +62,6 @@ func (q *LockQueue) Dequeue() *QueueRequest {
 	return req
 }
 
-// Remove removes a specific request by ID
 func (q *LockQueue) Remove(requestID string) *QueueRequest {
 	element, exists := q.requests[requestID]
 	if !exists {
@@ -80,7 +73,6 @@ func (q *LockQueue) Remove(requestID string) *QueueRequest {
 	return element.Value.(*QueueRequest)
 }
 
-// GetPosition returns the position of a request in the queue (1-based)
 func (q *LockQueue) GetPosition(requestID string) int {
 	element, exists := q.requests[requestID]
 	if !exists {
@@ -97,7 +89,6 @@ func (q *LockQueue) GetPosition(requestID string) int {
 	return -1
 }
 
-// GetNext returns the next request without removing it
 func (q *LockQueue) GetNext() *QueueRequest {
 	if q.list.Len() == 0 {
 		return nil
@@ -107,23 +98,18 @@ func (q *LockQueue) GetNext() *QueueRequest {
 	return element.Value.(*QueueRequest)
 }
 
-// Size returns the current queue size
 func (q *LockQueue) Size() int {
 	return q.list.Len()
 }
 
-// CleanExpired removes expired requests and returns the count removed
-// Only removes requests that have been expired for more than 5 seconds
-// to allow polling to detect recently expired requests
 func (q *LockQueue) CleanExpired(now time.Time) int {
 	removed := 0
-	gracePeriod := 5 * time.Second // Allow recently expired requests to be detected
+	gracePeriod := 5 * time.Second
 
 	for e := q.list.Front(); e != nil; {
 		req := e.Value.(*QueueRequest)
 		next := e.Next()
 
-		// Only remove if expired for more than the grace period
 		if now.After(req.TimeoutAt.Add(gracePeriod)) {
 			delete(q.requests, req.ID)
 			q.list.Remove(e)
@@ -134,11 +120,10 @@ func (q *LockQueue) CleanExpired(now time.Time) int {
 	return removed
 }
 
-func (l *Lock) IsAvailable() bool {
+func (l *Lock) IsAvailable(now time.Time) bool {
 	if l.OwnerID == "" {
 		return true
 	}
-	now := time.Now()
 	if now.After(l.AcquiredAt.Add(l.MaxTTL)) {
 		return true
 	}
@@ -158,7 +143,6 @@ func (l *Lock) GetOwner() string {
 	return "none"
 }
 
-// NewLockMetrics creates a new metrics instance for a lock
 func NewLockMetrics() *LockMetrics {
 	now := time.Now()
 	return &LockMetrics{
@@ -168,7 +152,6 @@ func NewLockMetrics() *LockMetrics {
 	}
 }
 
-// GetMetrics returns the lock's metrics (thread-safe)
 func (l *Lock) GetMetrics() *LockMetrics {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -177,7 +160,6 @@ func (l *Lock) GetMetrics() *LockMetrics {
 		l.metrics = NewLockMetrics()
 	}
 
-	// Update current metrics
 	l.metrics.CurrentQueueSize = int64(l.getCurrentQueueSize())
 	if !l.Available && l.OwnerID != "" {
 		l.metrics.CurrentHoldTime = time.Since(l.AcquiredAt)
@@ -186,7 +168,6 @@ func (l *Lock) GetMetrics() *LockMetrics {
 	return l.metrics
 }
 
-// recordAcquireAttempt records an acquire attempt
 func (l *Lock) recordAcquireAttempt(success bool) {
 	if l.metrics == nil {
 		l.metrics = NewLockMetrics()
@@ -202,7 +183,6 @@ func (l *Lock) recordAcquireAttempt(success bool) {
 	}
 }
 
-// recordQueueRequest records a queue request
 func (l *Lock) recordQueueRequest() {
 	if l.metrics == nil {
 		l.metrics = NewLockMetrics()
@@ -213,7 +193,6 @@ func (l *Lock) recordQueueRequest() {
 	l.metrics.LastActivityAt = time.Now()
 }
 
-// recordQueueTimeout records a queue timeout
 func (l *Lock) recordQueueTimeout() {
 	if l.metrics == nil {
 		return
@@ -223,7 +202,6 @@ func (l *Lock) recordQueueTimeout() {
 	atomic.AddInt64(&l.metrics.CurrentQueueSize, -1)
 }
 
-// recordOwnerChange records when ownership changes
 func (l *Lock) recordOwnerChange(newOwner, newOwnerID string, acquiredAt time.Time, maxSize int) {
 	if l.metrics == nil {
 		l.metrics = NewLockMetrics()
@@ -231,7 +209,6 @@ func (l *Lock) recordOwnerChange(newOwner, newOwnerID string, acquiredAt time.Ti
 
 	atomic.AddInt64(&l.metrics.OwnerChangeCount, 1)
 
-	// Check if this is a new unique owner
 	isUnique := true
 	for _, record := range l.metrics.OwnerHistory {
 		if record.OwnerID == newOwnerID {
@@ -243,9 +220,7 @@ func (l *Lock) recordOwnerChange(newOwner, newOwnerID string, acquiredAt time.Ti
 		atomic.AddInt64(&l.metrics.UniqueOwnersCount, 1)
 	}
 
-	// Record previous owner if lock was held
 	if l.OwnerID != "" && len(l.metrics.OwnerHistory) > 0 {
-		// Update the last record with release time
 		lastIdx := len(l.metrics.OwnerHistory) - 1
 		if l.metrics.OwnerHistory[lastIdx].ReleasedAt == nil {
 			releasedAt := time.Now()
@@ -254,7 +229,6 @@ func (l *Lock) recordOwnerChange(newOwner, newOwnerID string, acquiredAt time.Ti
 		}
 	}
 
-	// Add new owner record
 	record := OwnerRecord{
 		Owner:      newOwner,
 		OwnerID:    newOwnerID,
@@ -262,35 +236,29 @@ func (l *Lock) recordOwnerChange(newOwner, newOwnerID string, acquiredAt time.Ti
 	}
 	l.metrics.OwnerHistory = append(l.metrics.OwnerHistory, record)
 
-	// Keep only last maxSize records to prevent unbounded growth
 	if len(l.metrics.OwnerHistory) > maxSize {
 		l.metrics.OwnerHistory = l.metrics.OwnerHistory[len(l.metrics.OwnerHistory)-maxSize:]
 	}
 }
 
-// recordRelease records a lock release
 func (l *Lock) recordRelease() {
 	if l.metrics == nil {
 		return
 	}
 
-	// Update hold time statistics
 	holdTime := time.Since(l.AcquiredAt)
 	atomic.AddInt64((*int64)(&l.metrics.TotalHoldTime), int64(holdTime))
 
-	// Update average hold time
 	totalHolds := atomic.LoadInt64(&l.metrics.SuccessfulAcquires)
 	if totalHolds > 0 {
 		avgHoldTime := time.Duration(atomic.LoadInt64((*int64)(&l.metrics.TotalHoldTime)) / totalHolds)
 		atomic.StoreInt64((*int64)(&l.metrics.AverageHoldTime), int64(avgHoldTime))
 	}
 
-	// Update max hold time
 	if holdTime > l.metrics.MaxHoldTime {
 		l.metrics.MaxHoldTime = holdTime
 	}
 
-	// Update last owner record
 	if len(l.metrics.OwnerHistory) > 0 {
 		lastIdx := len(l.metrics.OwnerHistory) - 1
 		if l.metrics.OwnerHistory[lastIdx].ReleasedAt == nil {
@@ -303,7 +271,6 @@ func (l *Lock) recordRelease() {
 	l.metrics.LastActivityAt = time.Now()
 }
 
-// recordRefresh records a lock refresh
 func (l *Lock) recordRefresh() {
 	if l.metrics == nil {
 		return
@@ -313,7 +280,6 @@ func (l *Lock) recordRefresh() {
 	l.metrics.LastActivityAt = time.Now()
 }
 
-// recordTTLExpiration records a TTL expiration
 func (l *Lock) recordTTLExpiration() {
 	if l.metrics == nil {
 		return
@@ -323,7 +289,6 @@ func (l *Lock) recordTTLExpiration() {
 	l.metrics.LastActivityAt = time.Now()
 }
 
-// recordMaxTTLExpiration records a Max TTL expiration
 func (l *Lock) recordMaxTTLExpiration() {
 	if l.metrics == nil {
 		return
@@ -333,7 +298,6 @@ func (l *Lock) recordMaxTTLExpiration() {
 	l.metrics.LastActivityAt = time.Now()
 }
 
-// recordFailedOperation records a failed operation
 func (l *Lock) recordFailedOperation() {
 	if l.metrics == nil {
 		return
@@ -343,7 +307,6 @@ func (l *Lock) recordFailedOperation() {
 	l.metrics.LastActivityAt = time.Now()
 }
 
-// recordStaleToken records a stale token error
 func (l *Lock) recordStaleToken() {
 	if l.metrics == nil {
 		return
@@ -354,7 +317,6 @@ func (l *Lock) recordStaleToken() {
 	l.metrics.LastActivityAt = time.Now()
 }
 
-// getCurrentQueueSize returns the current queue size (thread-safe)
 func (l *Lock) getCurrentQueueSize() int {
 	if l.queue == nil {
 		return 0

--- a/glock-server/core/lock.go
+++ b/glock-server/core/lock.go
@@ -11,6 +11,7 @@ import (
 // @Description Lock represents a distributed lock with metadata and timing information
 type Lock struct {
 	Name         string        `json:"name" example:"my-lock"`
+	Parent       string        `json:"parent,omitempty" example:"/parent-lock"`
 	Owner        string        `json:"owner" example:"client-app"`
 	OwnerID      string        `json:"owner_id" example:"uuid-123"`
 	AcquiredAt   time.Time     `json:"acquired_at"`

--- a/glock-server/core/lock.go
+++ b/glock-server/core/lock.go
@@ -27,6 +27,7 @@ type Lock struct {
 	queue        *LockQueue    `json:"-"`
 	mu           sync.Mutex    `json:"-"`
 	metrics      *LockMetrics  `json:"-"`
+	isHeld       atomic.Bool   `json:"-"`
 }
 
 // LockQueue is now defined in queue.go

--- a/glock-server/core/lock_test.go
+++ b/glock-server/core/lock_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestIsAvailable_NoOwner(t *testing.T) {
 	l := &Lock{OwnerID: ""}
-	if !l.IsAvailable() {
+	if !l.IsAvailable(time.Now()) {
 		t.Fatalf("expected available when no owner")
 	}
 }
@@ -18,7 +18,7 @@ func TestIsAvailable_TTLExpired(t *testing.T) {
 		LastRefresh: time.Now().Add(-2 * time.Second),
 		TTL:         time.Second,
 	}
-	if !l.IsAvailable() {
+	if !l.IsAvailable(time.Now()) {
 		t.Fatalf("expected available when TTL expired")
 	}
 }
@@ -29,7 +29,7 @@ func TestIsAvailable_MaxTTLExpired(t *testing.T) {
 		AcquiredAt: time.Now().Add(-2 * time.Second),
 		MaxTTL:     time.Second,
 	}
-	if !l.IsAvailable() {
+	if !l.IsAvailable(time.Now()) {
 		t.Fatalf("expected available when MaxTTL expired")
 	}
 }
@@ -43,7 +43,7 @@ func TestIsAvailable_HeldAndNotExpired(t *testing.T) {
 		MaxTTL:      time.Hour,
 		Available:   false,
 	}
-	if l.IsAvailable() {
+	if l.IsAvailable(time.Now()) {
 		t.Fatalf("expected not available when held and not expired")
 	}
 }

--- a/glock-server/core/models.go
+++ b/glock-server/core/models.go
@@ -61,6 +61,7 @@ type CreateRequest struct {
 	Name         string        `json:"name" binding:"required" example:"my-lock"`
 	TTL          string        `json:"ttl" binding:"required" example:"30s"`
 	MaxTTL       string        `json:"max_ttl" binding:"required" example:"5m"`
+	Parent       string        `json:"parent,omitempty" example:"/parent-lock"`
 	Metadata     any           `json:"metadata"`
 	QueueType    QueueBehavior `json:"queue_type,omitempty" example:"fifo"`
 	QueueTimeout string        `json:"queue_timeout,omitempty" example:"1m"`
@@ -76,6 +77,7 @@ type UpdateRequest struct {
 	Name         string        `json:"name" binding:"required"`
 	TTL          string        `json:"ttl" binding:"required"`
 	MaxTTL       string        `json:"max_ttl" binding:"required"`
+	Parent 	 string        `json:"parent,omitempty"`
 	Metadata     any           `json:"metadata"`
 	QueueType    QueueBehavior `json:"queue_type,omitempty"`
 	QueueTimeout string        `json:"queue_timeout,omitempty"`

--- a/glock-server/core/queue.go
+++ b/glock-server/core/queue.go
@@ -1,0 +1,131 @@
+package core
+
+import (
+	"container/list"
+	"time"
+)
+
+// LockQueue manages a queue of lock acquisition requests.
+// It supports FIFO, LIFO ordering and tracks request positions.
+type LockQueue struct {
+	requests map[string]*list.Element
+	list     *list.List
+}
+
+// NewLockQueue creates a new empty lock queue.
+func NewLockQueue() *LockQueue {
+	return &LockQueue{
+		requests: make(map[string]*list.Element),
+		list:     list.New(),
+	}
+}
+
+// Enqueue adds a new request to the queue.
+// If isLIFO is true, the request is added to the front (LIFO behavior).
+// Otherwise, it's added to the back (FIFO behavior).
+func (q *LockQueue) Enqueue(req *QueueRequest, isLIFO bool) {
+	element := q.list.PushBack(req)
+	if isLIFO {
+		q.list.MoveToFront(element)
+	}
+	q.requests[req.ID] = element
+}
+
+// Dequeue removes and returns the next request from the front of the queue.
+// Returns nil if the queue is empty.
+func (q *LockQueue) Dequeue() *QueueRequest {
+	if q.list.Len() == 0 {
+		return nil
+	}
+
+	element := q.list.Front()
+	q.list.Remove(element)
+	req := element.Value.(*QueueRequest)
+	delete(q.requests, req.ID)
+	return req
+}
+
+// Remove removes a specific request by ID from the queue.
+// Returns the removed request or nil if not found.
+func (q *LockQueue) Remove(requestID string) *QueueRequest {
+	element, exists := q.requests[requestID]
+	if !exists {
+		return nil
+	}
+
+	delete(q.requests, requestID)
+	q.list.Remove(element)
+	return element.Value.(*QueueRequest)
+}
+
+// GetPosition returns the position of a request in the queue (1-indexed).
+// Returns -1 if the request is not found.
+func (q *LockQueue) GetPosition(requestID string) int {
+	element, exists := q.requests[requestID]
+	if !exists {
+		return -1
+	}
+
+	position := 1
+	for e := q.list.Front(); e != nil; e = e.Next() {
+		if e == element {
+			return position
+		}
+		position++
+	}
+	return -1
+}
+
+// PeekNext returns the next request without removing it from the queue.
+// Returns nil if the queue is empty.
+func (q *LockQueue) PeekNext() *QueueRequest {
+	if q.list.Len() == 0 {
+		return nil
+	}
+
+	element := q.list.Front()
+	return element.Value.(*QueueRequest)
+}
+
+// Size returns the number of requests currently in the queue.
+func (q *LockQueue) Size() int {
+	return q.list.Len()
+}
+
+// CleanExpired removes all expired requests from the queue.
+// A request is considered expired if the current time is after its timeout plus a grace period.
+// Returns the number of requests removed.
+func (q *LockQueue) CleanExpired(now time.Time) int {
+	removed := 0
+	gracePeriod := 5 * time.Second
+
+	for e := q.list.Front(); e != nil; {
+		req := e.Value.(*QueueRequest)
+		next := e.Next()
+
+		if now.After(req.TimeoutAt.Add(gracePeriod)) {
+			delete(q.requests, req.ID)
+			q.list.Remove(e)
+			removed++
+		}
+		e = next
+	}
+	return removed
+}
+
+// GetAll returns a slice of all requests currently in the queue.
+// The requests are returned in queue order (front to back).
+func (q *LockQueue) GetAll() []*QueueRequest {
+	requests := make([]*QueueRequest, 0, q.list.Len())
+	for e := q.list.Front(); e != nil; e = e.Next() {
+		req := e.Value.(*QueueRequest)
+		requests = append(requests, req)
+	}
+	return requests
+}
+
+// Contains checks if a request with the given ID exists in the queue.
+func (q *LockQueue) Contains(requestID string) bool {
+	_, exists := q.requests[requestID]
+	return exists
+}

--- a/glock-server/core/race_test.go
+++ b/glock-server/core/race_test.go
@@ -505,8 +505,8 @@ func TestQueueLIFOBehavior(t *testing.T) {
 	// Note: Client2's stored position is from when it was queued, so it shows position 1
 	// But the actual current position should be 2. Let's check the current position.
 	lockVal, _ := g.Locks.Load("lifo-test")
-	lock := lockVal.(*Lock)
-	currentPos2 := lock.queue.GetPosition(queueResp2.RequestID)
+	node := lockVal.(*Node)
+	currentPos2 := node.Lock.queue.GetPosition(queueResp2.RequestID)
 	if currentPos2 != 2 {
 		t.Fatalf("expected current second request position 2, got %d", currentPos2)
 	}

--- a/glock-server/core/race_test.go
+++ b/glock-server/core/race_test.go
@@ -752,16 +752,18 @@ func TestQueueSizeAndCleanup(t *testing.T) {
 		t.Fatalf("first request should be expired, got status=%s", pollResp.Status)
 	}
 
-	// Release lock - since all requests are expired, lock should become available
+	// Release lock - this will try to grant from queue, which will remove expired requests
 	g.ReleaseLock(&ReleaseRequest{Name: "size-test", OwnerID: "11111111-1111-1111-1111-111111111111", Token: lock1.Token})
 
-	// Poll second request - should be expired
+	// Poll second request - it should be not_found because release already cleaned expired requests
 	pollResp2, _, _ := g.PollQueue(&PollRequest{
 		Name:      "size-test",
 		RequestID: queueRequests[1].RequestID,
 		OwnerID:   "00031111-1111-1111-1111-111111111111",
 	})
-	if pollResp2.Status != "expired" {
-		t.Fatalf("second request should be expired, got status=%s", pollResp2.Status)
+	// With the new queue system, expired requests are removed proactively during tryGrantFromQueue
+	// So this request was already removed when we tried to grant during release
+	if pollResp2.Status != "not_found" && pollResp2.Status != "expired" {
+		t.Fatalf("second request should be not_found or expired, got status=%s", pollResp2.Status)
 	}
 }

--- a/glock-server/core/server_test.go
+++ b/glock-server/core/server_test.go
@@ -596,10 +596,7 @@ func TestTTLExpirationQueueProcessing(t *testing.T) {
 	// 3. Wait for TTL to expire
 	time.Sleep(100 * time.Millisecond) // Wait longer than TTL
 
-	// 4. Manually trigger the cleanup process (simulating the background goroutine)
-	g.processExpiredLocks()
-
-	// 5. Check if client2 got the lock
+	// 4. Poll to check - this will automatically detect TTL expiration and grant the lock
 	pollResp2, code3, err3 := g.PollQueue(&PollRequest{
 		Name:      "ttl-test-lock",
 		RequestID: requestID,
@@ -628,33 +625,30 @@ func TestTTLExpirationQueueProcessing(t *testing.T) {
 	}
 }
 
-// TestBackgroundCleanupGoroutine tests that the background cleanup works
-func TestBackgroundCleanupGoroutine(t *testing.T) {
+// TestQueueHandoffOnTTLExpiration tests that when a lock's TTL expires,
+// the next queued client automatically gets it when they poll
+func TestQueueHandoffOnTTLExpiration(t *testing.T) {
 	g := newServer(10)
 
 	// Create a lock with short TTL
 	_, _, _ = g.CreateLock(&CreateRequest{
-		Name:         "bg-cleanup-test",
+		Name:         "ttl-handoff-test",
 		TTL:          "10ms",
 		MaxTTL:       "100ms",
 		QueueType:    QueueFIFO,
 		QueueTimeout: "1s",
 	})
 
-	// Start the cleanup goroutine
-	g.StartCleanupGoroutine()
-	defer g.StopCleanupGoroutine()
-
 	// Acquire lock
 	_, _, _ = g.AcquireLock(&AcquireRequest{
-		Name:    "bg-cleanup-test",
+		Name:    "ttl-handoff-test",
 		Owner:   "owner1",
 		OwnerID: "11111111-1111-1111-1111-111111111111",
 	})
 
 	// Queue another client
 	result, code, err := g.AcquireLock(&AcquireRequest{
-		Name:    "bg-cleanup-test",
+		Name:    "ttl-handoff-test",
 		Owner:   "owner2",
 		OwnerID: "22222222-2222-2222-2222-222222222222",
 	})
@@ -663,21 +657,22 @@ func TestBackgroundCleanupGoroutine(t *testing.T) {
 	}
 	queueResp := result.(*QueueResponse)
 
-	// Wait for TTL to expire and background cleanup to run
-	time.Sleep(200 * time.Millisecond) // Wait for cleanup interval (30s default, but should be fast in test)
+	// Wait for TTL to expire
+	time.Sleep(50 * time.Millisecond)
 
-	// Poll to see if we got the lock
+	// Poll - this should detect the expired TTL and grant the lock automatically
 	pollResp, code2, _ := g.PollQueue(&PollRequest{
-		Name:      "bg-cleanup-test",
+		Name:      "ttl-handoff-test",
 		RequestID: queueResp.RequestID,
 		OwnerID:   "22222222-2222-2222-2222-222222222222",
 	})
 
-	// Should either get the lock or be told it's ready
-	if code2 == http.StatusOK && pollResp.Status == "ready" && pollResp.Lock != nil {
-		if pollResp.Lock.Owner != "owner2" {
-			t.Fatalf("expected owner2 to get the lock, got %s", pollResp.Lock.Owner)
-		}
+	// Should get the lock immediately because first owner's TTL expired
+	if code2 != http.StatusOK || pollResp.Status != "ready" || pollResp.Lock == nil {
+		t.Fatalf("expected to get the lock, got status=%s code=%d", pollResp.Status, code2)
+	}
+	if pollResp.Lock.Owner != "owner2" {
+		t.Fatalf("expected owner2 to get the lock, got %s", pollResp.Lock.Owner)
 	}
 }
 

--- a/glock-server/core/tree.go
+++ b/glock-server/core/tree.go
@@ -1,0 +1,77 @@
+package core
+
+import "time"
+
+type LockTree struct {
+	Root *Node
+}
+
+func NewLockTree() *LockTree {
+	return &LockTree{
+		Root: &Node{
+			Children: make(map[string]*Node),
+		},
+	}
+}
+
+type Node struct {
+	Name     string
+	Parent   *Node
+	Children map[string]*Node
+	Lock     *Lock
+}
+
+func NewNode(parent *Node, lock *Lock) *Node {
+	n := &Node{
+		Name:     lock.Name,
+		Parent:   parent,
+		Children: make(map[string]*Node),
+		Lock:     lock,
+	}
+	if parent != nil {
+		parent.Children[lock.Name] = n
+	}
+	return n
+}
+
+func (n *Node) AddChild(lock *Lock) *Node {
+	child := NewNode(n, lock)
+	n.Children[lock.Name] = child
+	return child
+}
+
+func (n *Node) Remove() {
+	if n.Parent != nil {
+		for _, child := range n.Children {
+			child.Parent = n.Parent
+			n.Parent.Children[child.Name] = child
+		}
+		delete(n.Parent.Children, n.Name)
+	}
+}
+
+func (n *Node) ChangeParent(newParent *Node) {
+	if n.Parent != nil {
+		delete(n.Parent.Children, n.Name)
+	}
+	n.Parent = newParent
+	newParent.Children[n.Name] = n
+}
+
+func (n *Node) IsAnyParentHeld(now time.Time) bool {
+	current := n.Parent
+	for current != nil && current.Lock != nil {
+		if !current.Lock.IsAvailable(now) {
+			return true
+		}
+		current = current.Parent
+	}
+	return false
+}
+
+func (n *Node) IsParentHeld(now time.Time) bool {
+	if n.Parent != nil && n.Parent.Lock != nil {
+		return !n.Parent.Lock.IsAvailable(now)
+	}
+	return false
+}

--- a/glock-server/core/tree_test.go
+++ b/glock-server/core/tree_test.go
@@ -1,0 +1,552 @@
+package core
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestNewLockTree(t *testing.T) {
+	tree := NewLockTree()
+	if tree == nil {
+		t.Fatal("NewLockTree returned nil")
+	}
+	if tree.Root == nil {
+		t.Fatal("tree root is nil")
+	}
+	if tree.Root.Children == nil {
+		t.Fatal("tree root children map is nil")
+	}
+}
+
+func TestNodeCreation(t *testing.T) {
+	tree := NewLockTree()
+	lock := &Lock{Name: "test-lock"}
+
+	node := NewNode(tree.Root, lock)
+	if node == nil {
+		t.Fatal("NewNode returned nil")
+	}
+	if node.Name != "test-lock" {
+		t.Fatalf("expected node name 'test-lock', got '%s'", node.Name)
+	}
+	if node.Parent != tree.Root {
+		t.Fatal("node parent not set correctly")
+	}
+	if node.Lock != lock {
+		t.Fatal("node lock not set correctly")
+	}
+}
+
+func TestNodeAddChild(t *testing.T) {
+	tree := NewLockTree()
+	parentLock := &Lock{Name: "parent"}
+	parentNode := NewNode(tree.Root, parentLock)
+
+	childLock := &Lock{Name: "child"}
+	childNode := parentNode.AddChild(childLock)
+
+	if childNode.Parent != parentNode {
+		t.Fatal("child parent not set correctly")
+	}
+	if parentNode.Children["child"] != childNode {
+		t.Fatal("child not added to parent's children map")
+	}
+}
+
+func TestNodeRemove(t *testing.T) {
+	tree := NewLockTree()
+	parentLock := &Lock{Name: "parent"}
+	parentNode := NewNode(tree.Root, parentLock)
+
+	childLock := &Lock{Name: "child"}
+	childNode := parentNode.AddChild(childLock)
+
+	grandchildLock := &Lock{Name: "grandchild"}
+	grandchildNode := childNode.AddChild(grandchildLock)
+
+	childNode.Remove()
+
+	if parentNode.Children["child"] != nil {
+		t.Fatal("child should be removed from parent")
+	}
+	if grandchildNode.Parent != parentNode {
+		t.Fatal("grandchild should be reparented to parent")
+	}
+	if parentNode.Children["grandchild"] != grandchildNode {
+		t.Fatal("grandchild should be in parent's children")
+	}
+}
+
+func TestNodeChangeParent(t *testing.T) {
+	tree := NewLockTree()
+	parent1Lock := &Lock{Name: "parent1"}
+	parent1Node := NewNode(tree.Root, parent1Lock)
+
+	parent2Lock := &Lock{Name: "parent2"}
+	parent2Node := NewNode(tree.Root, parent2Lock)
+
+	childLock := &Lock{Name: "child"}
+	childNode := parent1Node.AddChild(childLock)
+
+	childNode.ChangeParent(parent2Node)
+
+	if childNode.Parent != parent2Node {
+		t.Fatal("child parent not changed")
+	}
+	if parent1Node.Children["child"] != nil {
+		t.Fatal("child should be removed from old parent")
+	}
+	if parent2Node.Children["child"] != childNode {
+		t.Fatal("child should be added to new parent")
+	}
+}
+
+func TestIsParentHeld(t *testing.T) {
+	tree := NewLockTree()
+	parentLock := &Lock{
+		Name:        "parent",
+		OwnerID:     "owner1",
+		AcquiredAt:  time.Now(),
+		LastRefresh: time.Now(),
+		TTL:         time.Minute,
+		MaxTTL:      time.Hour,
+		Available:   false,
+	}
+	parentNode := NewNode(tree.Root, parentLock)
+
+	childLock := &Lock{Name: "child"}
+	childNode := parentNode.AddChild(childLock)
+
+	now := time.Now()
+	if !childNode.IsParentHeld(now) {
+		t.Fatal("expected parent to be held")
+	}
+
+	parentLock.Available = true
+	parentLock.OwnerID = ""
+	if childNode.IsParentHeld(now) {
+		t.Fatal("expected parent not to be held")
+	}
+}
+
+func TestIsParentHeldWithNoParentLock(t *testing.T) {
+	tree := NewLockTree()
+	lock := &Lock{Name: "root-lock"}
+	node := NewNode(tree.Root, lock)
+
+	now := time.Now()
+	if node.IsParentHeld(now) {
+		t.Fatal("root node should not have held parent")
+	}
+}
+
+func TestIsAnyParentHeld(t *testing.T) {
+	tree := NewLockTree()
+
+	grandparentLock := &Lock{
+		Name:        "grandparent",
+		OwnerID:     "owner1",
+		AcquiredAt:  time.Now(),
+		LastRefresh: time.Now(),
+		TTL:         time.Minute,
+		MaxTTL:      time.Hour,
+		Available:   false,
+	}
+	grandparentNode := NewNode(tree.Root, grandparentLock)
+
+	parentLock := &Lock{Name: "parent"}
+	parentNode := grandparentNode.AddChild(parentLock)
+
+	childLock := &Lock{Name: "child"}
+	childNode := parentNode.AddChild(childLock)
+
+	now := time.Now()
+	if !childNode.IsAnyParentHeld(now) {
+		t.Fatal("expected ancestor (grandparent) to be held")
+	}
+
+	grandparentLock.Available = true
+	grandparentLock.OwnerID = ""
+	if childNode.IsAnyParentHeld(now) {
+		t.Fatal("expected no ancestors to be held")
+	}
+}
+
+func TestIsAnyParentHeldMultipleLevels(t *testing.T) {
+	tree := NewLockTree()
+
+	level1Lock := &Lock{Name: "level1"}
+	level1Node := NewNode(tree.Root, level1Lock)
+
+	level2Lock := &Lock{
+		Name:        "level2",
+		OwnerID:     "owner2",
+		AcquiredAt:  time.Now(),
+		LastRefresh: time.Now(),
+		TTL:         time.Minute,
+		MaxTTL:      time.Hour,
+		Available:   false,
+	}
+	level2Node := level1Node.AddChild(level2Lock)
+
+	level3Lock := &Lock{Name: "level3"}
+	level3Node := level2Node.AddChild(level3Lock)
+
+	level4Lock := &Lock{Name: "level4"}
+	level4Node := level3Node.AddChild(level4Lock)
+
+	now := time.Now()
+	if !level4Node.IsAnyParentHeld(now) {
+		t.Fatal("expected level2 ancestor to be held")
+	}
+}
+
+func TestParentChildAcquireBlocking(t *testing.T) {
+	g := newServer(10)
+
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "parent", TTL: "1s", MaxTTL: "1m"})
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "child", Parent: "parent", TTL: "1s", MaxTTL: "1m"})
+
+	result, code, err := g.AcquireLock(&AcquireRequest{
+		Name:    "parent",
+		Owner:   "owner1",
+		OwnerID: "11111111-1111-1111-1111-111111111111",
+	})
+	if err != nil || code != http.StatusOK {
+		t.Fatalf("parent acquire failed: code=%d err=%v", code, err)
+	}
+	parentLock := result.(*Lock)
+
+	_, code, err = g.AcquireLock(&AcquireRequest{
+		Name:    "child",
+		Owner:   "owner2",
+		OwnerID: "22222222-2222-2222-2222-222222222222",
+	})
+	if err == nil || code != http.StatusConflict {
+		t.Fatalf("expected conflict when acquiring child with parent held, got code=%d err=%v", code, err)
+	}
+	if err.Error() != "cannot acquire lock: an ancestor lock is currently held" {
+		t.Fatalf("unexpected error message: %s", err.Error())
+	}
+
+	_, code, err = g.ReleaseLock(&ReleaseRequest{
+		Name:    "parent",
+		OwnerID: "11111111-1111-1111-1111-111111111111",
+		Token:   parentLock.Token,
+	})
+	if err != nil || code != http.StatusOK {
+		t.Fatalf("parent release failed: code=%d err=%v", code, err)
+	}
+
+	_, code, err = g.AcquireLock(&AcquireRequest{
+		Name:    "child",
+		Owner:   "owner2",
+		OwnerID: "22222222-2222-2222-2222-222222222222",
+	})
+	if err != nil || code != http.StatusOK {
+		t.Fatalf("child acquire should succeed after parent release, got code=%d err=%v", code, err)
+	}
+}
+
+func TestParentChildMultiLevel(t *testing.T) {
+	g := newServer(10)
+
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "grandparent", TTL: "1s", MaxTTL: "1m"})
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "parent", Parent: "grandparent", TTL: "1s", MaxTTL: "1m"})
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "child", Parent: "parent", TTL: "1s", MaxTTL: "1m"})
+
+	result, code, err := g.AcquireLock(&AcquireRequest{
+		Name:    "grandparent",
+		Owner:   "owner1",
+		OwnerID: "11111111-1111-1111-1111-111111111111",
+	})
+	if err != nil || code != http.StatusOK {
+		t.Fatalf("grandparent acquire failed: code=%d err=%v", code, err)
+	}
+	grandparentLock := result.(*Lock)
+
+	_, code, err = g.AcquireLock(&AcquireRequest{
+		Name:    "child",
+		Owner:   "owner2",
+		OwnerID: "22222222-2222-2222-2222-222222222222",
+	})
+	if err == nil || code != http.StatusConflict {
+		t.Fatalf("expected conflict when acquiring child with grandparent held, got code=%d", code)
+	}
+
+	g.ReleaseLock(&ReleaseRequest{
+		Name:    "grandparent",
+		OwnerID: "11111111-1111-1111-1111-111111111111",
+		Token:   grandparentLock.Token,
+	})
+
+	_, code, err = g.AcquireLock(&AcquireRequest{
+		Name:    "child",
+		Owner:   "owner2",
+		OwnerID: "22222222-2222-2222-2222-222222222222",
+	})
+	if err != nil || code != http.StatusOK {
+		t.Fatalf("child acquire should succeed after grandparent release, got code=%d err=%v", code, err)
+	}
+}
+
+func TestDeleteWithParentHeld(t *testing.T) {
+	g := newServer(10)
+
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "parent", TTL: "1s", MaxTTL: "1m"})
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "child", Parent: "parent", TTL: "1s", MaxTTL: "1m"})
+
+	result, _, _ := g.AcquireLock(&AcquireRequest{
+		Name:    "parent",
+		Owner:   "owner1",
+		OwnerID: "11111111-1111-1111-1111-111111111111",
+	})
+	parentLock := result.(*Lock)
+
+	_, code, err := g.DeleteLock("child")
+	if err == nil || code != http.StatusConflict {
+		t.Fatalf("expected conflict when deleting child with parent held, got code=%d err=%v", code, err)
+	}
+	if err.Error() != "cannot delete lock: parent lock is currently held" {
+		t.Fatalf("unexpected error message: %s", err.Error())
+	}
+
+	g.ReleaseLock(&ReleaseRequest{
+		Name:    "parent",
+		OwnerID: "11111111-1111-1111-1111-111111111111",
+		Token:   parentLock.Token,
+	})
+
+	ok, code, err := g.DeleteLock("child")
+	if err != nil || code != http.StatusOK || !ok {
+		t.Fatalf("child delete should succeed after parent release, got code=%d err=%v ok=%v", code, err, ok)
+	}
+}
+
+func TestUpdateParentWithAncestorHeld(t *testing.T) {
+	g := newServer(10)
+
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "parent1", TTL: "1s", MaxTTL: "1m"})
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "parent2", TTL: "1s", MaxTTL: "1m"})
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "grandparent", TTL: "1s", MaxTTL: "1m"})
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "child", Parent: "parent1", TTL: "1s", MaxTTL: "1m"})
+
+	result, _, _ := g.AcquireLock(&AcquireRequest{
+		Name:    "grandparent",
+		Owner:   "owner1",
+		OwnerID: "11111111-1111-1111-1111-111111111111",
+	})
+	grandparentLock := result.(*Lock)
+
+	_, _, _ = g.UpdateLock(&UpdateRequest{
+		Name:   "parent2",
+		Parent: "grandparent",
+		TTL:    "2s",
+		MaxTTL: "2m",
+	})
+
+	_, code, err := g.UpdateLock(&UpdateRequest{
+		Name:   "child",
+		Parent: "parent2",
+		TTL:    "2s",
+		MaxTTL: "2m",
+	})
+	if err == nil || code != http.StatusConflict {
+		t.Fatalf("expected conflict when changing parent to one with held ancestor, got code=%d err=%v", code, err)
+	}
+	if err.Error() != "cannot change parent: an ancestor lock is currently held" {
+		t.Fatalf("unexpected error message: %s", err.Error())
+	}
+
+	g.ReleaseLock(&ReleaseRequest{
+		Name:    "grandparent",
+		OwnerID: "11111111-1111-1111-1111-111111111111",
+		Token:   grandparentLock.Token,
+	})
+
+	_, code, err = g.UpdateLock(&UpdateRequest{
+		Name:   "child",
+		Parent: "parent2",
+		TTL:    "2s",
+		MaxTTL: "2m",
+	})
+	if err != nil || code != http.StatusOK {
+		t.Fatalf("update should succeed after grandparent release, got code=%d err=%v", code, err)
+	}
+}
+
+func TestChildCanBeAcquiredIndependently(t *testing.T) {
+	g := newServer(10)
+
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "parent", TTL: "1s", MaxTTL: "1m"})
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "child", Parent: "parent", TTL: "1s", MaxTTL: "1m"})
+
+	result, code, err := g.AcquireLock(&AcquireRequest{
+		Name:    "child",
+		Owner:   "owner1",
+		OwnerID: "11111111-1111-1111-1111-111111111111",
+	})
+	if err != nil || code != http.StatusOK {
+		t.Fatalf("child acquire should succeed when parent not held, got code=%d err=%v", code, err)
+	}
+	childLock := result.(*Lock)
+
+	result, code, err = g.AcquireLock(&AcquireRequest{
+		Name:    "parent",
+		Owner:   "owner2",
+		OwnerID: "22222222-2222-2222-2222-222222222222",
+	})
+	if err != nil || code != http.StatusOK {
+		t.Fatalf("parent acquire should succeed even with child held, got code=%d err=%v", code, err)
+	}
+	parentLock := result.(*Lock)
+
+	g.ReleaseLock(&ReleaseRequest{
+		Name:    "child",
+		OwnerID: "11111111-1111-1111-1111-111111111111",
+		Token:   childLock.Token,
+	})
+
+	g.ReleaseLock(&ReleaseRequest{
+		Name:    "parent",
+		OwnerID: "22222222-2222-2222-2222-222222222222",
+		Token:   parentLock.Token,
+	})
+}
+
+func TestParentChildWithTTLExpiration(t *testing.T) {
+	g := newServer(10)
+
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "parent", TTL: "50ms", MaxTTL: "1s"})
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "child", Parent: "parent", TTL: "1s", MaxTTL: "1m"})
+
+	result, _, _ := g.AcquireLock(&AcquireRequest{
+		Name:    "parent",
+		Owner:   "owner1",
+		OwnerID: "11111111-1111-1111-1111-111111111111",
+	})
+	parentLock := result.(*Lock)
+
+	_, code, err := g.AcquireLock(&AcquireRequest{
+		Name:    "child",
+		Owner:   "owner2",
+		OwnerID: "22222222-2222-2222-2222-222222222222",
+	})
+	if err == nil || code != http.StatusConflict {
+		t.Fatalf("expected conflict when parent held, got code=%d", code)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	_, code, err = g.AcquireLock(&AcquireRequest{
+		Name:    "child",
+		Owner:   "owner2",
+		OwnerID: "22222222-2222-2222-2222-222222222222",
+	})
+	if err != nil || code != http.StatusOK {
+		t.Fatalf("child acquire should succeed after parent TTL expired, got code=%d err=%v", code, err)
+	}
+
+	_, code, err = g.RefreshLock(&RefreshRequest{
+		Name:    "parent",
+		OwnerID: "11111111-1111-1111-1111-111111111111",
+		Token:   parentLock.Token,
+	})
+	if err == nil || code != http.StatusConflict {
+		t.Fatalf("parent refresh should fail after TTL expiration, got code=%d", code)
+	}
+}
+
+func TestCreateChildWithNonExistentParent(t *testing.T) {
+	g := newServer(10)
+
+	_, code, err := g.CreateLock(&CreateRequest{
+		Name:   "child",
+		Parent: "non-existent-parent",
+		TTL:    "1s",
+		MaxTTL: "1m",
+	})
+	if err == nil || code != http.StatusBadRequest {
+		t.Fatalf("expected bad request when creating child with non-existent parent, got code=%d err=%v", code, err)
+	}
+}
+
+func TestUpdateToNonExistentParent(t *testing.T) {
+	g := newServer(10)
+
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "child", TTL: "1s", MaxTTL: "1m"})
+
+	_, code, err := g.UpdateLock(&UpdateRequest{
+		Name:   "child",
+		Parent: "non-existent-parent",
+		TTL:    "2s",
+		MaxTTL: "2m",
+	})
+	if err == nil || code != http.StatusBadRequest {
+		t.Fatalf("expected bad request when updating to non-existent parent, got code=%d err=%v", code, err)
+	}
+}
+
+func TestComplexHierarchy(t *testing.T) {
+	g := newServer(20)
+
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "root", TTL: "1s", MaxTTL: "1m"})
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "branch1", Parent: "root", TTL: "1s", MaxTTL: "1m"})
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "branch2", Parent: "root", TTL: "1s", MaxTTL: "1m"})
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "leaf1-1", Parent: "branch1", TTL: "1s", MaxTTL: "1m"})
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "leaf1-2", Parent: "branch1", TTL: "1s", MaxTTL: "1m"})
+	_, _, _ = g.CreateLock(&CreateRequest{Name: "leaf2-1", Parent: "branch2", TTL: "1s", MaxTTL: "1m"})
+
+	result, code, err := g.AcquireLock(&AcquireRequest{
+		Name:    "root",
+		Owner:   "owner1",
+		OwnerID: "11111111-1111-1111-1111-111111111111",
+	})
+	if err != nil || code != http.StatusOK {
+		t.Fatalf("root acquire failed")
+	}
+	rootLock := result.(*Lock)
+
+	_, code, _ = g.AcquireLock(&AcquireRequest{
+		Name:    "leaf1-1",
+		Owner:   "owner2",
+		OwnerID: "22222222-2222-2222-2222-222222222222",
+	})
+	if code == http.StatusOK {
+		t.Fatal("leaf1-1 should not be acquirable when root is held")
+	}
+
+	_, code, _ = g.AcquireLock(&AcquireRequest{
+		Name:    "leaf2-1",
+		Owner:   "owner3",
+		OwnerID: "33333333-3333-3333-3333-333333333333",
+	})
+	if code == http.StatusOK {
+		t.Fatal("leaf2-1 should not be acquirable when root is held")
+	}
+
+	g.ReleaseLock(&ReleaseRequest{
+		Name:    "root",
+		OwnerID: "11111111-1111-1111-1111-111111111111",
+		Token:   rootLock.Token,
+	})
+
+	_, code, err = g.AcquireLock(&AcquireRequest{
+		Name:    "leaf1-1",
+		Owner:   "owner2",
+		OwnerID: "22222222-2222-2222-2222-222222222222",
+	})
+	if err != nil || code != http.StatusOK {
+		t.Fatal("leaf1-1 should be acquirable after root release")
+	}
+
+	_, code, err = g.AcquireLock(&AcquireRequest{
+		Name:    "leaf2-1",
+		Owner:   "owner3",
+		OwnerID: "33333333-3333-3333-3333-333333333333",
+	})
+	if err != nil || code != http.StatusOK {
+		t.Fatal("leaf2-1 should be acquirable after root release")
+	}
+}

--- a/glock-server/static/css/dashboard.css
+++ b/glock-server/static/css/dashboard.css
@@ -44,6 +44,30 @@
     background: #fde68a !important;
 }
 
+.blocked-row {
+    background: #fffbeb !important;
+    border-left: 3px solid #f59e0b;
+}
+
+.blocked-row:hover {
+    background: #fef3c7 !important;
+}
+
+/* Lock parent info styling */
+.lock-parent-info {
+    font-size: 11px;
+    color: #6b7280;
+    font-style: italic;
+    margin-top: 2px;
+    display: block;
+}
+
+.owner-blocked {
+    color: #92400e;
+    font-style: italic;
+    cursor: help;
+}
+
 /* Status Badges Enhancement */
 .status-badge {
     display: inline-block;
@@ -79,6 +103,13 @@
     background-color: #f3e8ff;
     color: #6b21a8;
     border-color: #d8b4fe;
+}
+
+.status-blocked {
+    background-color: #fef3c7;
+    color: #92400e;
+    border-color: #fde68a;
+    cursor: help;
 }
 
 /* Time Remaining Styles */
@@ -415,8 +446,8 @@
     }
 }
 
-/* Dark Mode Support (for future enhancement) */
-@media (prefers-color-scheme: dark) {
+/* Dark Mode Support (disabled for now) */
+/* @media (prefers-color-scheme: dark) {
     .locks-table th {
         background: linear-gradient(135deg, #4a5568 0%, #2d3748 100%);
     }
@@ -424,7 +455,7 @@
     .locks-table tbody tr:hover {
         background-color: #2d3748;
     }
-}
+} */
 
 /* Print Styles */
 @media print {

--- a/glock-server/static/index.html
+++ b/glock-server/static/index.html
@@ -36,6 +36,7 @@
                         <option value="">All Status</option>
                         <option value="available">Available</option>
                         <option value="held">Held</option>
+                        <option value="blocked">Blocked</option>
                         <option value="expired">Expired</option>
                     </select>
                 </div>
@@ -54,6 +55,10 @@
             <div class="stat-card">
                 <div class="stat-number" id="held-locks">0</div>
                 <div class="stat-label">Held</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-number" id="blocked-locks">0</div>
+                <div class="stat-label">Blocked</div>
             </div>
             <div class="stat-card">
                 <div class="stat-number" id="expired-locks">0</div>
@@ -104,6 +109,17 @@
                 <div class="form-group">
                     <label for="create-name">Lock Name *</label>
                     <input type="text" id="create-name" name="name" required>
+                </div>
+                <div class="form-group">
+                    <div class="label-with-help">
+                        <label for="create-parent">Parent Lock</label>
+                        <div class="help-tooltip">
+                            ⓘ
+                            <span class="help-tooltip-text">Optional parent lock that must be held for this lock to be
+                                acquired</span>
+                        </div>
+                    </div>
+                    <input type="text" id="create-parent" name="parent" placeholder="/parent-lock-name">
                 </div>
                 <div class="form-row">
                     <div class="form-group">
@@ -175,6 +191,17 @@
             </div>
             <form id="update-lock-form">
                 <input type="hidden" id="update-lock-name" name="name">
+                <div class="form-group">
+                    <div class="label-with-help">
+                        <label for="update-parent">Parent Lock</label>
+                        <div class="help-tooltip">
+                            ⓘ
+                            <span class="help-tooltip-text">Optional parent lock that must be held for this lock to be
+                                acquired</span>
+                        </div>
+                    </div>
+                    <input type="text" id="update-parent" name="parent" placeholder="/parent-lock-name">
+                </div>
                 <div class="form-row">
                     <div class="form-group">
                         <div class="label-with-help">

--- a/glock/models.go
+++ b/glock/models.go
@@ -13,6 +13,7 @@ type CreateRequest struct {
 	Name         string        `json:"name" binding:"required"`
 	TTL          string        `json:"ttl" binding:"required"`
 	MaxTTL       string        `json:"max_ttl" binding:"required"`
+	Parent       string        `json:"parent,omitempty"`
 	Metadata     any           `json:"metadata"`
 	QueueType    QueueBehavior `json:"queue_type,omitempty"`
 	QueueTimeout string        `json:"queue_timeout,omitempty"`
@@ -26,6 +27,7 @@ type UpdateRequest struct {
 	Name         string        `json:"name" binding:"required"`
 	TTL          string        `json:"ttl" binding:"required"`
 	MaxTTL       string        `json:"max_ttl" binding:"required"`
+	Parent       string        `json:"parent,omitempty"`
 	Metadata     any           `json:"metadata"`
 	QueueType    QueueBehavior `json:"queue_type,omitempty"`
 	QueueTimeout string        `json:"queue_timeout,omitempty"`


### PR DESCRIPTION
implements parent-child locks

behavior:
- if a lock is acquired, any of its descendants are also held
- if a lock is acquired, none of its ancestors or descendants can be acquired
- if a lock is held, an acquire request for one of its descendants will queue
- if a parent and child both have a queue, the parent will take priority